### PR TITLE
(SIMP-MAINT) Set permissions on /var/log/audit.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,7 +45,7 @@ class auditd::config {
   file { '/etc/audit/audit.rules':
     owner => 'root',
     group => $auditd::log_group,
-    mode  => 'o-rwx'
+    mode  => $log_file_mode
   }
 
   # Build the auditd.conf from parts
@@ -86,10 +86,11 @@ class auditd::config {
   }
 
   file { '/var/log/audit':
-    ensure => 'directory',
-    owner  => 'root',
-    group  => $auditd::log_group,
-    mode   => 'o-rwx'
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => $auditd::log_group,
+    mode    => $log_file_mode,
+    recurse => true,
   }
 
   file { $auditd::log_file:


### PR DESCRIPTION
Sets the directory permissions to ensure $log_group can traverse the parent directory.

Also sets permissions on /etc/audit/audit.rules.